### PR TITLE
update to CF 3.7.0

### DIFF
--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -166,7 +166,7 @@
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
       <!--      <version>0.5.1</version>-->
-      <version>3.6.1</version>
+      <version>3.7.0</version>
       <!--      <scope>system</scope>-->
       <!--      <systemPath>${env.CHECKERFRAMEWORK}/checker/dist/jdk8.jar</systemPath>-->
     </dependency>
@@ -356,7 +356,7 @@
             <path>
               <groupId>org.checkerframework</groupId>
               <artifactId>checker</artifactId>
-              <version>3.6.1</version>
+              <version>3.7.0</version>
             </path>
           </annotationProcessorPaths>
           <compilerArgs combine.children="append">


### PR DESCRIPTION
Update to latest CF so that latest version of ACC runs on this.

I'm not sure why this is really necessary - shouldn't these dependencies come from the Always Call Checker directly via its dependencies? Why do they also need to be specified here?